### PR TITLE
emacs 23.1 on centos 6.0 will have string-prefix-p void function error

### DIFF
--- a/init.el
+++ b/init.el
@@ -1,3 +1,13 @@
+;make .emacs.d support emacs 23.1 and above
+
+;only emacs 23.3 and above has string-prefix-p defined
+(if (not (fboundp 'string-prefix-p) )
+  (defun string-prefix-p (shorter longer)
+    (let ((n (mismatch shorter longer))
+	  (l (length shorter)))
+      (if (or (not n) (= n l)) l nil)))
+  )
+
 ;; -*- coding: utf-8 -*-
 (add-to-list 'load-path (expand-file-name "~/.emacs.d"))
 


### PR DESCRIPTION
the key problem is string-prefix-p does not exist.
I tried to install to emacs 23.3 on centos 6.0 but looks it's troublesome
