### PR TITLE
workergroup2 needs to be fetched from melpa unstable

### DIFF
--- a/lisp/init-elpa.el
+++ b/lisp/init-elpa.el
@@ -50,6 +50,7 @@ But you may use safer HTTPS instead.")
     textile-mode
     w3m
     erlang
+    workgroups2
     company-c-headers)
   "Don't install any Melpa packages except these packages")
 


### PR DESCRIPTION
Emacs complain on workgroup2 not found at startup, a further check indicates that workgroup2 seems to be  from melpa unstable. Add it into the list ...