### PR TITLE
Add package org-download and disable echo message from keyfreq

### DIFF
--- a/init.el
+++ b/init.el
@@ -78,6 +78,7 @@
   (require 'init-erlang)
   (require 'init-javascript)
   (require 'init-org)
+  (require 'init-org-download)
   (require 'init-css)
   (require 'init-python-mode)
   (require 'init-haskell)

--- a/lisp/init-keyfreq.el
+++ b/lisp/init-keyfreq.el
@@ -230,4 +230,15 @@
 ;; comment out below line if there is performance impact
 (turnon-keyfreq-mode)
 
+;; Disable noisy echo message and keep silent.
+(defun keyfreq-autosave--do-silent ()
+  "Function executed periodically to save the `keyfreq-table' in `keyfreq-file'."
+  ;; I want to exit emacs as usually even there is exception here
+  (condition-case nil
+      (progn
+        (keyfreq-table-save keyfreq-table))
+    (error
+     (message "%s is corrupt" keyfreq-file))))
+(advice-add 'keyfreq-autosave--do :override #'keyfreq-autosave--do-silent)
+
 (provide 'init-keyfreq)

--- a/lisp/init-org-download.el
+++ b/lisp/init-org-download.el
@@ -1,0 +1,9 @@
+;; @see https://github.com/abo-abo/org-download
+
+(push 'org-download melpa-include-packages)
+(require-package 'org-download)
+(require 'org-download)
+
+(setq org-download-method 'attach)
+
+(provide 'init-org-download)


### PR DESCRIPTION
1. org-download is image DND (Drag and drop) extension for org-mode.
for user who need manipulate images a lot make org-download very useful.
not only for DND, but links, and screenshot integration.
 refer: https://github.com/abo-abo/org-download

2. keyfreq always output "keyfreq data saved into..." and may interrupt
user input, disable this noisy message to keep silent unless failure
occured.