### PR TITLE
Fix misuse of `start-process' in sdcv.el and clean up code.

### DIFF
--- a/site-lisp/sdcv/sdcv.el
+++ b/site-lisp/sdcv/sdcv.el
@@ -375,9 +375,6 @@ Argument DICTIONARY-LIST the word that need transform."
   ;; Record current translate object.
   (setq sdcv-current-translate-object word)
 
-  (mapconcat (lambda (dict)
-               (concat "-u \"" dict "\""))
-             dictionary-list " ")
   ;; Return translate result.
   (let (cmd)
     (sdcv-filter

--- a/site-lisp/sdcv/sdcv.el
+++ b/site-lisp/sdcv/sdcv.el
@@ -355,17 +355,12 @@ The result will be displayed in buffer named with
   (with-current-buffer (get-buffer-create sdcv-buffer-name)
     (setq buffer-read-only nil)
     (erase-buffer)
-    (let* ((process
-            (start-process
-             "sdcv" sdcv-buffer-name "sdcv"
-             (sdcv-search-witch-dictionary word sdcv-dictionary-complete-list))))
-      (set-process-sentinel
-       process
-       (lambda (process signal)
-         (when (memq (process-status process) '(exit signal))
-           (unless (eq (current-buffer) (sdcv-get-buffer))
-             (sdcv-goto-sdcv))
-           (sdcv-mode-reinit)))))))
+    (insert (sdcv-search-witch-dictionary
+             word
+             sdcv-dictionary-complete-list)))
+  (unless (eq (current-buffer) (sdcv-get-buffer))
+    (sdcv-goto-sdcv))
+  (sdcv-mode-reinit))
 
 (defun sdcv-search-simple (&optional word)
   "Search WORD simple translate result."


### PR DESCRIPTION
P.S. https://www.emacswiki.org/emacs/download/sdcv.el has changed to use showtip instead of popup, do you want to merge it?