### PR TITLE
Fix an argument error in the advice for `dired-guess-default'.

### DIFF
--- a/lisp/init-dired.el
+++ b/lisp/init-dired.el
@@ -39,7 +39,7 @@ if no files marked, always operate on current line in dired-mode
     ad-do-it))
 
 (defadvice dired-guess-default (after dired-guess-default-after-hack activate)
-  (if (string-match-p "^mplayer -quiet" ad-return-value)
+  (if (and (stringp ad-return-value) (string-match-p "^mplayer -quiet" ad-return-value))
       (let* ((dir (file-name-as-directory (concat default-directory
                                                   "Subs")))
              basename)


### PR DESCRIPTION
How to reproduce:
1. `C-x d` to open `/tmp/`, which contains a org file `foo.org`, and move point on it.
2. type `!` to execute shell command, then an error occurs complaining:

    ad-Advice-dired-guess-default: Wrong type argument: stringp, nil