### PR TITLE
Don't change coding system when cleaning buffer up.

### DIFF
--- a/lisp/init-misc-lazy.el
+++ b/lisp/init-misc-lazy.el
@@ -418,8 +418,7 @@ Does not indent buffer, because it is used for a before-save-hook, and that
 might be bad."
   (interactive)
   (untabify (point-min) (point-max))
-  (delete-trailing-whitespace)
-  (set-buffer-file-coding-system 'utf-8))
+  (delete-trailing-whitespace))
 
 (defun cleanup-buffer ()
   "Perform a bunch of operations on the whitespace content of a buffer.


### PR DESCRIPTION
BTW, `indent-buffer` called in `cleanup-buffer` doesn't exist:

    Symbol’s function definition is void: indent-buffer

`M-x version`:

    GNU Emacs 25.3.1 (x86_64-redhat-linux-gnu, GTK+ Version 3.22.19) of 2017-09-15
