### PR TITLE
Add kill-buffer-in-nth-window

### DIFF
--- a/lisp/init-utils.el
+++ b/lisp/init-utils.el
@@ -337,6 +337,4 @@ you can '(setq my-mplayer-extra-opts \"-ao alsa -vo vdpau\")'.")
       )))
 
 ;; }}
-
-
 (provide 'init-utils)

--- a/lisp/init-utils.el
+++ b/lisp/init-utils.el
@@ -337,4 +337,28 @@ you can '(setq my-mplayer-extra-opts \"-ao alsa -vo vdpau\")'.")
       )))
 
 ;; }}
+
+
+;; buffer related {{
+(defun kill-buffer-in-nth-window (&optional win-num)
+  "Kill the buffer in nth window, default to next window
+If WIN-NUM is provided (via prefix in C-u), kill the buffer in window numbered WIN-NUM
+
+Used for killing temporary/auto buffers like *help*, *manual* .etc, also useful
+in kill buffer in other window while keeping window split untouched."
+  (interactive "p")
+  (let ((tgt-win)
+        (cur-buf-name (buffer-name))
+        (cur-win (selected-window)))
+    (if win-num
+        (setq tgt-win (select-window-by-number win-num))
+      (setq tgt-win (next-window)))
+    (select-window tgt-win)
+    (if (eq cur-buf-name (buffer-name))
+        (message "Same buffer, do nothing")
+      (kill-this-buffer))
+    (select-window cur-win)))
+
+(global-set-key (kbd "C-x K") 'kill-buffer-in-nth-window)
+;; }}
 (provide 'init-utils)

--- a/lisp/init-utils.el
+++ b/lisp/init-utils.el
@@ -346,7 +346,7 @@ If WIN-NUM is provided (via prefix in C-u), kill the buffer in window numbered W
 
 Used for killing temporary/auto buffers like *help*, *manual* .etc, also useful
 in kill buffer in other window while keeping window split untouched."
-  (interactive "p")
+  (interactive "P")
   (let ((tgt-win)
         (cur-buf-name (buffer-name))
         (cur-win (selected-window)))

--- a/lisp/init-utils.el
+++ b/lisp/init-utils.el
@@ -339,26 +339,4 @@ you can '(setq my-mplayer-extra-opts \"-ao alsa -vo vdpau\")'.")
 ;; }}
 
 
-;; buffer related {{
-(defun kill-buffer-in-nth-window (&optional win-num)
-  "Kill the buffer in nth window, default to next window
-If WIN-NUM is provided (via prefix in C-u), kill the buffer in window numbered WIN-NUM
-
-Used for killing temporary/auto buffers like *help*, *manual* .etc, also useful
-in kill buffer in other window while keeping window split untouched."
-  (interactive "P")
-  (let ((tgt-win)
-        (cur-buf-name (buffer-name))
-        (cur-win (selected-window)))
-    (if win-num
-        (setq tgt-win (select-window-by-number win-num))
-      (setq tgt-win (next-window)))
-    (select-window tgt-win)
-    (if (eq cur-buf-name (buffer-name))
-        (message "Same buffer, do nothing")
-      (kill-this-buffer))
-    (select-window cur-win)))
-
-(global-set-key (kbd "C-x K") 'kill-buffer-in-nth-window)
-;; }}
 (provide 'init-utils)

--- a/lisp/init-windows.el
+++ b/lisp/init-windows.el
@@ -113,4 +113,28 @@ Always focus on bigger window."
              (set-window-start w2 s1)
              (setq i (1+ i)))))))
 
+;; buffer related {{
+(defun kill-buffer-in-nth-window (&optional win-num)
+  "Kill the buffer in nth window, default to next window
+If WIN-NUM is provided (via prefix in C-u), kill the buffer in window numbered WIN-NUM
+
+Used for killing temporary/auto buffers like *help*, *manual* .etc, also useful
+in kill buffer in other window while keeping window split untouched."
+  (interactive "P")
+  (let ((tgt-win)
+        (cur-buf-name (buffer-name))
+        (cur-win (selected-window)))
+    (if win-num
+        (setq tgt-win (select-window-by-number win-num))
+      (setq tgt-win (next-window)))
+    (select-window tgt-win)
+    (if (eq cur-buf-name (buffer-name))
+        (message "Same buffer, do nothing")
+      (kill-this-buffer))
+    (select-window cur-win)))
+
+(global-set-key (kbd "C-x K") 'kill-buffer-in-nth-window)
+;; }}
+
+
 (provide 'init-windows)


### PR DESCRIPTION
I like to split multiple windows when reading code (one for invocation, another for definition .etc), and very frequently I will check manual for some POSIX API, and would like to kill the manual buffer as soon as I know the definition, while keeping the cursor in current buffer. 

Previously I would have to switch to the window that contains the auto buffer, `q` or `,xk` to kill the buffer, then switch back to the original window. This is quite annoying and I cannot find a good solution. Hence the DIY in this commit :)