### PR TITLE
Install yasnippet-snippets seperately

### DIFF
--- a/lisp/init-elpa.el
+++ b/lisp/init-elpa.el
@@ -269,6 +269,7 @@
 (require-package 'git-link)
 (require-package 'cliphist)
 (require-package 'yasnippet)
+(require-package 'yasnippet-snippets)
 (require-package 'company)
 (require-package 'company-c-headers)
 (require-package 'company-statistics)


### PR DESCRIPTION
yasnippet had removed yasnippet-snippets as a submodule: https://github.com/joaotavora/yasnippet/commit/b1ca2197062340d4c9e78442ea38957a96f968d4