### PR TITLE
Add missing helpers and fix obsolete function for `hydra-window`.

### DIFF
--- a/lisp/init-hydra.el
+++ b/lisp/init-hydra.el
@@ -203,6 +203,43 @@ _w_ whitespace-mode:   %`whitespace-mode
 ;; }}
 
 ;; {{ @see https://github.com/abo-abo/hydra/wiki/Window-Management
+
+;; helpers from https://github.com/abo-abo/hydra/blob/master/hydra-examples.el
+(unless (featurep 'windmove)
+  (require 'windmove))
+
+(defun hydra-move-splitter-left (arg)
+  "Move window splitter left."
+  (interactive "p")
+  (if (let ((windmove-wrap-around))
+        (windmove-find-other-window 'right))
+      (shrink-window-horizontally arg)
+    (enlarge-window-horizontally arg)))
+
+(defun hydra-move-splitter-right (arg)
+  "Move window splitter right."
+  (interactive "p")
+  (if (let ((windmove-wrap-around))
+        (windmove-find-other-window 'right))
+      (enlarge-window-horizontally arg)
+    (shrink-window-horizontally arg)))
+
+(defun hydra-move-splitter-up (arg)
+  "Move window splitter up."
+  (interactive "p")
+  (if (let ((windmove-wrap-around))
+        (windmove-find-other-window 'up))
+      (enlarge-window arg)
+    (shrink-window arg)))
+
+(defun hydra-move-splitter-down (arg)
+  "Move window splitter down."
+  (interactive "p")
+  (if (let ((windmove-wrap-around))
+        (windmove-find-other-window 'up))
+      (shrink-window arg)
+    (enlarge-window arg)))
+
 (defhydra hydra-window ()
   "
 Movement^^   ^Split^         ^Switch^     ^Resize^
@@ -251,7 +288,7 @@ _SPC_ cancel _o_nly this     _d_elete
          (add-hook 'ace-window-end-once-hook
                    'hydra-window/body)))
   ("o" delete-other-windows)
-  ("i" ace-maximize-window)
+  ("i" ace-delete-other-windows)
   ("z" (progn
          (winner-undo)
          (setq this-command 'winner-undo)))


### PR DESCRIPTION
Hi,

This PR fixes errors like "Wrong type argument: commandp, ace-maximize-window" when using `hydra-window`,
`ace-maximize-window` was marked obsolete in `ace-window` 0.10.0(see its [repo](https://github.com/abo-abo/ace-window/blob/master/ace-window.el#L532)),
which is not yet released in stable melpa though.

But since we allow to install `ace-window` from "unstable" melpa, I think it's safe to just use its successor.
