### PR TITLE
Bugfix: use `yas-text` instead of `text` in snippets.

### DIFF
--- a/snippets/java-mode/classes/property.yasnippet
+++ b/snippets/java-mode/classes/property.yasnippet
@@ -4,10 +4,10 @@
 # --
 private ${1:String} ${2:name};$0
 
-public $1 get${2:$(upcase-initials text)}() {
+public $1 get${2:$(upcase-initials yas-text)}() {
     return $2;
 }
 
-public void set${2:$(upcase-initials text)}($1 $2) {
+public void set${2:$(upcase-initials yas-text)}($1 $2) {
     this.$2 = $2;
 }

--- a/snippets/objc-mode/prop
+++ b/snippets/objc-mode/prop
@@ -5,7 +5,7 @@
     return $2;
 }
 
-- (void)set${2:$(capitalize text)}:($1)aValue
+- (void)set${2:$(capitalize yas-text)}:($1)aValue
 {
     [$2 autorelease];
     $2 = [aValue retain];

--- a/snippets/rspec-mode/befm
+++ b/snippets/rspec-mode/befm
@@ -1,5 +1,5 @@
 #name : before (rspec)
 # --
 before(:each) do
-  @${1:model} = ${1:$(replace-regexp-in-string "_" "" (upcase-initials text))}.new$0
+  @${1:model} = ${1:$(replace-regexp-in-string "_" "" (upcase-initials yas-text))}.new$0
 end

--- a/snippets/ruby-mode/befm
+++ b/snippets/ruby-mode/befm
@@ -1,5 +1,5 @@
 #name : before (rspec)
 # --
 before(:each) do
-  @${1:model} = ${1:$(replace-regexp-in-string "_" "" (upcase-initials text))}.new$0
+  @${1:model} = ${1:$(replace-regexp-in-string "_" "" (upcase-initials yas-text))}.new$0
 end


### PR DESCRIPTION
Hi,

This fix an error when `M-x yas-expand` `prop` in `java-mode`:

    Wrong type argument: stringp, (text)

FYI, yasnippet replaced `text` with `yas-text` years ago:

1. https://github.com/joaotavora/yasnippet/commit/6ce6b24f52f27a3a26492d058a99692354c5421c
2. https://github.com/joaotavora/yasnippet/commit/f98c527a38b08d1f8b786660a627887475dc7323
