### PR TITLE
Fix duplicate

### DIFF
--- a/README.org
+++ b/README.org
@@ -428,7 +428,7 @@ If you use Zsh instead of Bash, please modify =init-term-mode.el=.
 ** Setup fonts in GUI Emacs
 Non-Chinese can use [[https://github.com/rolandwalker/unicode-fonts][unicode-fonts]].
 
-Chinese can use [[https://github.com/tumashu/chinese-fonts-setup][chinese-fonts-setup]].
+Chinese can use [[https://github.com/tumashu/cnfonts][cnfonts]].
 
 They are not included in this setup. You need install them manually.
 ** Synchronize setup with Git

--- a/lisp/init-essential.el
+++ b/lisp/init-essential.el
@@ -210,15 +210,17 @@ If OTHER-SOURCE is 2, get keyword from `kill-ring'."
 ;; Show a marker in the left fringe for lines not in the buffer
 (setq indicate-empty-lines t)
 
-;; NO tool bar
-(if (fboundp 'tool-bar-mode)
-  (tool-bar-mode -1))
-;; no scroll bar
-(if (fboundp 'set-scroll-bar-mode)
-  (set-scroll-bar-mode nil))
+;; NO tool bar, scroll-bar
+(when window-system
+  (and (fboundp 'scroll-bar-mode) (not (eq scroll-bar-mode -1))
+       (scroll-bar-mode -1))
+  (and (fboundp 'tool-bar-mode) (not (eq tool-bar-mode -1))
+       (tool-bar-mode -1))
+  (and (fboundp 'horizontal-scroll-bar-mode)
+       (horizontal-scroll-bar-mode -1)))
 ;; no menu bar
-(if (fboundp 'menu-bar-mode)
-  (menu-bar-mode -1))
+(and (fboundp 'menu-bar-mode) (not (eq menu-bar-mode -1))
+     (menu-bar-mode -1))
 ;; }}
 
 (provide 'init-essential)

--- a/lisp/init-misc.el
+++ b/lisp/init-misc.el
@@ -246,8 +246,6 @@ This function can be re-used by other major modes after compilation."
 (defalias 'list-buffers 'ibuffer)
 
                                         ;effective emacs item 7; no scrollbar, no menubar, no toolbar
-(if (fboundp 'scroll-bar-mode) (scroll-bar-mode -1))
-(if (fboundp 'tool-bar-mode) (tool-bar-mode -1))
 
 (defun my-download-subtitles ()
   (interactive)


### PR DESCRIPTION
* 更新了`cnfonts`的地址

* `tool-bar` `scroll-bar` `menu-bar`分布在两个文件里，统一了一下；并且`set-scroll-bar-mode`好像只在gui里有，终端模式下没有这个mode；所以添加了一个`window-system`来判断是不是在终端情况下，并且在终端模式下都没有`tool-bar-mode`和`scroll-bar-mode`的定义（可以通过`emacs --batch -f tool-bar-mode`判断）