### PR TITLE
adjust shortkey and clean useless code

### DIFF
--- a/lisp/init-evil.el
+++ b/lisp/init-evil.el
@@ -656,8 +656,8 @@ If the character before and after CH is space or tab, CH is NOT slash"
   "ee" 'evil-iedit-state/iedit-mode ; start iedit in emacs to rename variables in defun
   "sc" 'shell-command
   "ll" 'my-wg-switch-workgroup ; load windows layout
-  "kk" 'scroll-other-window
-  "jj" 'scroll-other-window-up
+  "jj" 'scroll-other-window
+  "kk" 'scroll-other-window-up
   "hh" 'random-healthy-color-theme
   "yy" 'hydra-launcher/body
   "ii" 'my-toggle-indentation

--- a/lisp/init-misc.el
+++ b/lisp/init-misc.el
@@ -245,8 +245,6 @@ This function can be re-used by other major modes after compilation."
 
 (defalias 'list-buffers 'ibuffer)
 
-                                        ;effective emacs item 7; no scrollbar, no menubar, no toolbar
-
 (defun my-download-subtitles ()
   (interactive)
   (shell-command "periscope.py -l en *.mkv *.mp4 *.avi &"))


### PR DESCRIPTION
`init-evil.el`里`scroll-other-window`函数的按键是不是设置反了😂不应该是j向下翻页，k向上翻页吗？

另外在`init-evil.el`等文件里看到还有一些`gud`的相关函数，是不是都已经没用了？
https://github.com/redguardtoo/emacs.d/blob/b5962a2ac04b8f219f1523a0c1ed00b5e050bdb4/lisp/init-evil.el#L687-L695

===

另外关于[init-modeline.el](https://github.com/redguardtoo/emacs.d/blob/master/lisp/init-modeline.el)有个问题想咨询一下您。
`propertize`函数里的`help-echo`所起的作用应该是在gui界面下鼠标悬停时所回显的信息吧？（我不是很懂elisp😅）因为我平时要处理一些文本，所以需要看到文本的相应编码，`mode-line-format`自带的`%Z`并不能满足我的需求。所以我自定义了一个函数，并添加到`mode-line-format`里。
```
(defun my-mode-line-buffer-encoding ()
  "Ending convention used in the buffer."
  (let ((buffer-coding (format "%s" buffer-file-coding-system)))
    (if (string-match "\\(utf-8\\|big5\\|gb18030\\)" buffer-coding)
      (match-string 1 buffer-coding)
      buffer-coding)))
---
(setq-default mode-line-format
...
    '(:eval (my-mode-line-buffer-encoding))
...
```
但是保存时会自动更改为`utf-8`，不知道是哪裏出了问题。。。另外请问有没有什么简便的方法来检测文件的文本编码吗？

还有一个对缩进的处理问题，您不考虑使用下[editorconfig-emacs](https://github.com/editorconfig/editorconfig-emacs)这个插件吗？