### PR TITLE
Update init-evil.el

### DIFF
--- a/lisp/init-evil.el
+++ b/lisp/init-evil.el
@@ -231,7 +231,7 @@ If the character before and after CH is space or tab, CH is NOT slash"
 (evil-declare-key 'normal markdown-mode-map
   "gh" 'outline-up-heading
   "gl" 'outline-next-visible-heading
-  (kbd "TAB") 'org-cycle)
+  (kbd "TAB") 'markdown-cycle)
 
 ;; {{ specify major mode uses Evil (vim) NORMAL state or EMACS original state.
 ;; You may delete this setup to use Evil NORMAL state always.


### PR DESCRIPTION
在markdown-mode下使用`org-cycle` 只能展开各级标题，应该使用`markdown-cycle`来代替

并且我注意到您使用了`evil-lion`这个插件，这个插件的操作前缀是`gl`，这跟下面两行定义的快捷键应该是有冲突的，我个人是直接用`C-c C-f/C-n`来跳转的
https://github.com/redguardtoo/emacs.d/blob/7caea8491242f1c9ae66c60174e5cd5cc5cc038a/lisp/init-evil.el#L224
https://github.com/redguardtoo/emacs.d/blob/7caea8491242f1c9ae66c60174e5cd5cc5cc038a/lisp/init-evil.el#L233