### PR TITLE
bit of code cleanup in init-clipboard.el

### DIFF
--- a/lisp/init-clipboard.el
+++ b/lisp/init-clipboard.el
@@ -66,13 +66,13 @@ If N is not nil, copy file name and line number."
                                 (message "%s%s" msg hint)))))
 
 (defun copy-to-x-clipboard (&optional num)
-  "If NUM equals 1, copy the downcased string.
-If NUM equals 2, copy the captalized string.
-If NUM equals 3, copy the upcased string.
+  "If NUM equals 1, copy the down-cased string.
+If NUM equals 2, copy the capitalised string.
+If NUM equals 3, copy the up-cased string.
 If NUM equals 4, indent 4 spaces."
   (interactive "P")
   (let* ((thing (my-use-selected-string-or-ask "")))
-    (if (region-active-p) (deactivate-mark))
+    (when (region-active-p) (deactivate-mark))
     (cond
      ((not num))
      ((= num 1)
@@ -88,14 +88,15 @@ If NUM equals 4, indent 4 spaces."
       (message "C-h f copy-to-x-clipboard to find right usage")))
 
     (my-pclip thing)
-    (if (not (and num (= 4 num))) (message "kill-ring => clipboard")
+    (if (not (and num (= 4 num)))
+        (message "kill-ring => clipboard")
       (message "thing => clipboard!"))))
 
-(defun paste-from-x-clipboard(&optional n)
+(defun paste-from-x-clipboard (&optional n)
   "Remove selected text and paste string clipboard.
 If N is 1, we paste diff hunk whose leading char should be removed.
 If N is 2, paste into `kill-ring' too.
-If N is 3, converted dashed to camelcased then paste.
+If N is 3, converted dashed to camel-cased then paste.
 If N is 4, rectangle paste. "
   (interactive "P")
   (when (and (functionp 'evil-normal-state-p)
@@ -104,9 +105,8 @@ If N is 4, rectangle paste. "
              (not (eolp))
              (not (eobp)))
     (forward-char))
-  (let* ((str (my-gclip))
-         (fn 'insert))
-
+  (let ((str
+         (my-gclip)))
     (when (> (length str) (* 256 1024))
       ;; use light weight `major-mode' like `js-mode'
       (when (derived-mode-p 'js2-mode)
@@ -119,22 +119,22 @@ If N is 4, rectangle paste. "
                (boundp 'lsp-mode)
                lsp-mode)
       (lsp-disconnect)
-      (run-at-time 300 nil  #'lsp-deferred))
+      (run-at-time 300 nil #'lsp-deferred))
 
     (my-delete-selected-region)
 
     ;; paste after the cursor in evil normal state
-    (cond
-     ((not n)) ; do nothing
-     ((= 1 n)
-      (setq str (replace-regexp-in-string "^\\(+\\|-\\|@@ $\\)" "" str)))
-     ((= 2 n)
-      (kill-new str))
-     ((= 3 n)
-      (setq str (mapconcat (lambda (s) (capitalize s)) (split-string str "-") "")))
-     ((= 4 n)
-      (setq fn 'insert-rectangle)
-      (setq str (split-string str "[\r]?\n"))))
-    (funcall fn str)))
+    (cond ((not n))                     ; do nothing
+          ((= 1 n)
+           (insert (replace-regexp-in-string "^\\(+\\|-\\|@@ $\\)" "" str)))
+          ((= 2 n)
+           (kill-new str)
+           (insert str))
+          ((= 3 n)
+           (insert (mapconcat (lambda (s) (capitalize s))
+                              (split-string str "-")
+                              "")))
+          ((= 4 n)
+           (insert-rectangle (split-string str "[\r]?\n"))))))
 
 (provide 'init-clipboard)


### PR DESCRIPTION
My commit message format is messed up, but here's the essentially the same brief

## changes summary

only one file is affected `init-clipboard.el`

+ added a space to `paste-from-x-clipboard`
+ changed `paste-from-x-clipboard` to be more functional

+ fixed a few spelling error that `flyspell` suggested
