### PR TITLE
fix org-demote-or-promote special case

### DIFF
--- a/lisp/init-org.el
+++ b/lisp/init-org.el
@@ -36,8 +36,14 @@
 (defun org-demote-or-promote (&optional is-promote)
   "Demote or promote current org tree."
   (interactive "P")
-  (unless (region-active-p)
-    (org-mark-subtree))
+  (save-excursion
+    (beginning-of-line)
+    (unless (or (region-active-p)
+                (let ((line (thing-at-point 'line t)))
+                  (and (string-match-p "^\\*+ $" line) ;; is node only one spaced
+                       (= (point) (- (point-max) (length line))) ;; is line at EOF
+                       )))
+      (org-mark-subtree)))
   (if is-promote (org-do-promote) (org-do-demote)))
 
 ;; {{ @see http://orgmode.org/worg/org-contrib/org-mime.html


### PR DESCRIPTION
## commit brief
This commit contains my fix (attempt) to a special case that `org-demote-or-promote` may not function as intended.

## issue brief
When an org node (heading) is the last line of the file, and only one space is after the node heading (the `*`s). Using `org-demote-or-promote` (key bind `>`) will not promote the node.
```
... ;; any text/nodes
;; the following node only has one space after it
* 
```
The current behaviour of the command will highlight the line the node is in.
If there is any text after the node in any form, however, the command will work as intended, i.e promoting the current node (*) to (**), and its subtree if any.

## where the issue lies
For some reason when promoting/demoting a node in this special case, marking its subtree prevents `org-do-promote` and `org-do-demote` from functioning properly.

My fix is to check for this special case, and not mark subtree so the node can be promoted/demoted