### PR TITLE
Update init-misc.el

### DIFF
--- a/lisp/init-misc.el
+++ b/lisp/init-misc.el
@@ -912,18 +912,11 @@ If the shell is already opened in some buffer, switch to that buffer."
   (beginning-of-buffer))
 
 ;; {{ unique lines
-(defun uniq-lines ()
-  "Delete duplicate lines in region or buffer."
-  (interactive)
-  (let* ((a (region-active-p))
-         (start (if a (region-beginning) (point-min)))
-         (end (if a (region-end) (point-max))))
-    (save-excursion
-      (while
-          (progn
-            (goto-char start)
-            (re-search-forward "^\\(.*\\)\n\\(\\(.*\n\\)*\\)\\1\n" end t))
-        (replace-match "\\1\n\\2")))))
+;; https://gist.github.com/ramn/796527
+;; uniq-lines
+(defun uniq-lines (start end)
+  (interactive "*r")
+  (delete-duplicate-lines start end))
 ;; }}
 
 (defun my-insert-file-link-from-clipboard ()


### PR DESCRIPTION
replace uniq-lines with delete-duplicate-lines, bc the original
impliment has bugs, it invode re-search-forward by "bound", but
re-search-forward's doc said "The match found must not end after that position."
I have check in emacs/src/search.c: search_command/search_buffer_re as 
https://github.com/emacs-mirror/emacs/blob/master/src/search.c#L1152
it received the argument "lim", but didn't USE it. 
bugs will occur like below file, when I select "aaa" to "bb", and run your
"uniq-lines", it delete duplicate "code"s.
```text
aaa
aaa
aaa
bb
bb
code
code
code
```