### PR TITLE
Update init-javascript.el

### DIFF
--- a/lisp/init-javascript.el
+++ b/lisp/init-javascript.el
@@ -121,7 +121,7 @@ INDENT-SIZE decide the indentation level.
               web-mode-code-indent-offset)
 
              ((memq major-mode '(typescript-mode))
-              typescript-indent-size)
+              typescript-indent-level)
 
              (t
               2))))


### PR DESCRIPTION
use `typescript-indent-level` instead of `typescript-indent-size`

There is no variable named `typescript-indent-size` in `typescript-mode`.