### PR TITLE
fix my-extended-regexp

### DIFF
--- a/lisp/init-utils.el
+++ b/lisp/init-utils.el
@@ -552,7 +552,7 @@ Copied from 3rd party package evil-textobj."
 
      ;; If the first character of input in ivy is ":" or ";",
      ;; remaining input is converted into Chinese pinyin regex.
-     ((string-match (substring str 0 1) ":;")
+     ((string-match "[:\|;]" (substring str 0 1))
       (my-ensure 'pinyinlib)
       (setq str (pinyinlib-build-regexp-string (substring str 1 len))))
 


### PR DESCRIPTION
# Reproduction steps
Open swiper and search `\[`, it will call (my-extended-regexp "\\[")

The original code will try to compile user input `[` as regexp, and break the function.