### PR TITLE
Update the name of omtose-phellack-themes

### DIFF
--- a/lisp/init-elpa.el
+++ b/lisp/init-elpa.el
@@ -459,7 +459,7 @@ If NO-REFRESH is nil, `package-refresh-contents' is called."
     obsidian-theme
     occidental-theme
     oldlace-theme
-    omtose-phellack-theme
+    omtose-phellack-themes
     organic-green-theme
     phoenix-dark-mono-theme
     phoenix-dark-pink-theme


### PR DESCRIPTION
The theme name has changed from "omtose-phellack-theme" to "omtose-phellack-themes" last week.

See https://github.com/emacsorphanage/omtose-phellack-themes for more details