### PR TITLE
Fix error: (wrong-type-argument keymapp nil)

### DIFF
--- a/lisp/init-dictionary.el
+++ b/lisp/init-dictionary.el
@@ -51,6 +51,7 @@
     (when def
       (setq buf (get-buffer-create my-dict-buffer-name))
         (with-current-buffer buf
+          (special-mode)
           (setq buffer-read-only nil)
           (erase-buffer)
           (insert def)


### PR DESCRIPTION
This error occurs because evil-local-set-key expects a valid keymap, but at the time it's being called from my end, the buffer may not have been properly initialized with a major mode that sets up the keymaps. See error details below,

```
Debugger entered--Lisp error: (wrong-type-argument keymapp nil)
  define-key(nil "q" my-dict-quit-window)
  evil-local-set-key(normal "q" my-dict-quit-window)
  (progn (evil-local-set-key 'normal (kbd "q") 'my-dict-quit-window))
  (if (and (boundp 'evil-mode) evil-mode) (progn (evil-local-set-key 'normal (kbd "q") 'my-dict-quit-window)))
  (save-current-buffer (set-buffer buf) (setq buffer-read-only nil) (erase-buffer) (insert def) (goto-char (point-min)) (local-set-key (kbd "q") 'my-dict-quit-window) (if (and (boundp 'evil-mode) evil-mode) (progn (evil-local-set-key 'normal (kbd "q") 'my-dict-quit-window))))
  (progn (setq buf (get-buffer-create my-dict-buffer-name)) (save-current-buffer (set-buffer buf) (setq buffer-read-only nil) (erase-buffer) (insert def) (goto-char (point-min)) (local-set-key (kbd "q") 'my-dict-quit-window) (if (and (boundp 'evil-mode) evil-mode) (progn (evil-local-set-key 'normal (kbd "q") 'my-dict-quit-window)))) (if (eq (current-buffer) buf) nil (if (null (setq win (get-buffer-window buf))) (switch-to-buffer-other-window buf) (select-window win))))
...
```