### PR TITLE
fix: typo in init-evil.el — missing 'f' in find-file-in-project-at-point

### DIFF
--- a/lisp/init-evil.el
+++ b/lisp/init-evil.el
@@ -516,7 +516,7 @@ If N > 0 and in js, only occurrences in current N lines are renamed."
   "ff" 'my-toggle-full-window ;; I use WIN+F in i3
   "ip" 'find-file-in-project
   "tt" 'find-file-in-current-directory
-  "jj" 'ind-file-in-project-at-point
+  "jj" 'find-file-in-project-at-point
   "kk" 'find-file-in-project-by-selected
   "kn" 'find-file-with-similar-name ; ffip v5.3.1
   "kd" 'find-directory-in-project-by-selected


### PR DESCRIPTION
## Summary
Fixed a typo in `lisp/init-evil.el` line 519 where `ind-file-in-project-at-point` was missing the leading `'f'`, making it `'find-file-in-project-at-point`.

## Root Cause
The function name `find-file-in-project-at-point` was accidentally typed as `ind-file-in-project-at-point` (missing the first character `'f'`).

## Testing Done
- Verified the fix by checking the diff: `git diff` shows the single character change
- The corrected function name `find-file-in-project-at-point` is consistent with other bindings in the same file (e.g., `find-file-in-project`, `find-file-in-current-directory`, `find-file-in-project-by-selected`)

Fixes #1090